### PR TITLE
Summarizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2.0
+  - 2.3.0
   - 2.5.0
 before_install: gem install bundler -v 1.16.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ sudo: false
 language: ruby
 rvm:
   - 2.4.1
-before_install: gem install bundler -v 1.16.0.pre.2
+before_install: gem install bundler -v 1.16.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.1
+  - 2.2.0
+  - 2.5.0
 before_install: gem install bundler -v 1.16.1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SiteHealth
+# SiteHealth [![Build Status](https://travis-ci.org/buren/site_health.svg?branch=master)](https://travis-ci.org/buren/site_health)
 
 :warning: Project is still experimental, API will change (a lot) without notice.
 

--- a/lib/site_health/nurse.rb
+++ b/lib/site_health/nurse.rb
@@ -33,6 +33,10 @@ module SiteHealth
     # @return [Hash] result data
     def check_page(page)
       @pages_journal[page.url].tap do |journal|
+        started_at = Time.now
+        journal[:started_at] = started_at
+
+        journal[:url] = page.url
         journal[:content_type] = page.content_type
         journal[:http_status] = page.code
         journal[:redirect] = page.redirect?
@@ -43,6 +47,10 @@ module SiteHealth
         end
 
         journal[:checks] = lab_results(page)
+
+        finished_at = Time.now
+        journal[:finished_at] = finished_at
+        journal[:runtime_in_seconds] = (finished_at - started_at).round(1)
         clerk.emit_page(page, journal)
       end
     end

--- a/lib/site_health/summarizers/page_size_summarizer.rb
+++ b/lib/site_health/summarizers/page_size_summarizer.rb
@@ -1,0 +1,73 @@
+module SiteHealth
+  class PageSpeedSummarizer
+    def initialize(data)
+      @data = data
+    end
+
+    def to_csv
+      to_matrix.map { |row| row.join(',') }.join("\n")
+    end
+
+    def to_matrix
+      header = %w[
+        url
+        total_speed_score
+        css_kb
+        html_kb
+        image_kb
+        javascript_kb
+        other_kb
+        total_kbytes
+        number_hosts
+        number_js_resources
+        number_css_resources
+        number_resources
+        number_static_resources
+        started_at
+        finished_at
+        runtime_in_seconds
+      ]
+      rows = @data.map do |url, data|
+        pagespeed_data = data.dig(:checks, :google_page_speed)
+        next unless pagespeed_data
+
+        url = data[:url]
+        started_at = data[:started_at]
+        finished_at = data[:finished_at]
+        runtime = data[:runtime_in_seconds]
+
+        build_row(url, runtime, started_at, finished_at, pagespeed_data)
+      end.reject(&:nil?)
+
+      [header] + rows
+    end
+
+    def build_row(url, runtime_in_seconds, started_at, finished_at, pagespeed_data)
+      stats = pagespeed_data[:page_stats]
+
+      kbytes_columns = [
+        bytes_to_kb(stats[:css_response_bytes]),
+        bytes_to_kb(stats[:html_response_bytes]),
+        bytes_to_kb(stats[:image_response_bytes]),
+        bytes_to_kb(stats[:javascript_response_bytes]),
+        bytes_to_kb(stats[:other_response_bytes])
+      ]
+      kbytes_columns << kbytes_columns.sum
+
+      host_columns = [
+        stats[:number_hosts],
+        stats[:number_js_resources],
+        stats[:number_css_resources],
+        stats[:number_resources],
+        stats[:number_static_resources]
+      ]
+
+      total_speed_score = pagespeed_data.dig(:rule_groups, :SPEED, :score)
+      [url, total_speed_score] + kbytes_columns + host_columns + [started_at, finished_at, runtime_in_seconds]
+    end
+
+    def bytes_to_kb(bytes, round: 1)
+      (bytes / 1024.0).round(round)
+    end
+  end
+end


### PR DESCRIPTION
## Nurse meta data

`Nurse#journal` now returns `started_at`, `finished_at` and `runtime_in_seconds`.

---

## Page speed report summarizer

__Example__:

```ruby
nurse = SiteHealth.check_urls(['https://example.com'])
summary = SiteHealth::PageSpeedSummarizer.new(nurse.journal[:checked_urls])

File.write("tmp/page_size_summarizer.csv", summary.to_csv)
```